### PR TITLE
Include latest driver within the same repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # fixRTL8723BE
-Some HP laptops with **Realtek rtl8723be NICs** having one antenna face problems connecting to WiFi. This repository provides an automated fix for the problem by installing the latest drivers provided by [this](https://github.com/lwfinger/rtlwifi_new) repo and making the necessary configurations.
+Some HP laptops with **Realtek rtl8723be NICs** having one antenna face problems connecting to WiFi. This repository provides an automated fix for the problem by installing the latest driver and making the necessary configurations.
+The [original repo](https://github.com/tarunbatra/fixRTL8723BE) of this fork requires that you download the latest driver from another [Github repo](https://github.com/lwfinger/rtlwifi_new). I modified it to include the latest driver in the same repo since you probably don't have access to the internet each time you're tring to fix your wifi.
 
 ## Installation
 Just clone this repo. To clone, run:
 
-`git clone https://github.com/tarunbatra/fixRTL8723BE`
+`git clone https://github.com/nourharidy/fixRTL8723BE`
 
 ## Usage
 - `cd` to the project root

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fixRTL8723BE
 Some HP laptops with **Realtek rtl8723be NICs** having one antenna face problems connecting to WiFi. This repository provides an automated fix for the problem by installing the latest driver and making the necessary configurations.
-The [original repo](https://github.com/tarunbatra/fixRTL8723BE) of this fork requires that you download the latest driver from another [Github repo](https://github.com/lwfinger/rtlwifi_new). I modified it to include the latest driver in the same repo since you probably don't have access to the internet each time you're tring to fix your wifi.
+The [original repo](https://github.com/tarunbatra/fixRTL8723BE) of this fork requires that you download the latest driver from another [Github repo](https://github.com/lwfinger/rtlwifi_new). I modified it to include the latest driver in the same repo since you probably don't have access to the internet when you're trying to fix your wifi.
 
 ## Installation
 Just clone this repo. To clone, run:

--- a/install.sh
+++ b/install.sh
@@ -1,33 +1,10 @@
 #!/usr/bin env bash
+# Modified version by @nourharidy
 
-REPO="https://github.com/lwfinger/rtlwifi_new"
 CONFIG_DIR=`pwd`
 
-checkGit() {
-  if git --version  &> /dev/null; then
-    echo "Git found"
-  else
-    echo "Git not found"
-  fi
-}
-
-installGit() {
-  echo "Installing git\n"
-  sudo apt-get install git >> /dev/null
-}
-
-cloneRepo() {
-  echo "Downloading latest drivers from $REPO"
-  if git clone $REPO /tmp/rtlwifi_new_$$; then
-    echo "Drivers downloaded successfully"
-  else
-    echo "Download couldn't be completed. Exiting"
-    exit 1
-  fi
-}
-
 installDrivers() {
-  cd /tmp/rtlwifi_new_$$ || (echo "Drivers not found"; exit 1)
+  cd ./rtlwifi_new_11043 || (echo "Drivers not found"; exit 1)
   echo "Building drivers"
   if make && sudo make install; then
     echo "Drivers built successfully"
@@ -56,8 +33,6 @@ restartWiFi() {
 }
 
 echo "Fixing Wifi"
-checkGit || installGit
-cloneRepo $REPO
 installDrivers
 configureWiFi $CONFIG_DIR
 restartWiFi


### PR DESCRIPTION
My fork includes the latest RTL8723BE driver in the same repo since the user probably doesn't have access to the internet when trying to fix the wifi.